### PR TITLE
[JENKINS] Allow enabling CSRF and disabling insecure protocols

### DIFF
--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -118,7 +118,20 @@ data:
       </views>
       <primaryView>All</primaryView>
       <slaveAgentPort>50000</slaveAgentPort>
+      <disabledAgentProtocols>
+{{- range $key, $val := .Values.Master.DisabledAgentProtocols }}
+        <string>{{ $val }}</string>
+{{- end }}
+      </disabledAgentProtocols>
+
       <label></label>
+{{- if .Values.CSRF.CrumbIssuer }}
+      <crumbIssuer class="hudson.security.csrf.DefaultCrumbIssuer">
+{{- if .Values.CSRF.CrumbIssuer.ProxyCompatability }}
+        <excludeClientIPFromCrumb>true</excludeClientIPFromCrumb>
+{{- end }}
+      </crumbIssuer>
+{{- end }}
       <nodeProperties/>
       <globalNodeProperties/>
       <noUsageStatistics>true</noUsageStatistics>


### PR DESCRIPTION
This PR makes a more secure out-of-the-box configuration for Jenkins installs by allowing the user to disable insecure agent protocols, enable CSRF, and disable CLI over remoting, while still allowing a user to run with their pants down if they so wish.

- [x]  Add toggles to config template
- [x]  Secure defaults
- [x]  Add documentation